### PR TITLE
Remove `release/` from Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -13,7 +13,8 @@
 bin/
 gen/
 out/
-release/
+#  Uncomment the following line in case you need and you don't have the release build type files in your app
+# release/
 
 # Gradle files
 .gradle/


### PR DESCRIPTION
Having `release/` in an Android project gitignore means those apps which have different
build types files for `debug` and `release` will fall into this 
and all `release` related files will be never added or will be removed from
repository at some point.

This is one sample of using the release folder:
https://stackoverflow.com/a/39789566/2359762
